### PR TITLE
Improving builds and some fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,20 @@
-apply plugin: 'java'
-apply plugin: 'idea'
+plugins {
+    id "java"
+    id "idea"
+    id "application"
+    id "com.github.ben-manes.versions" version "0.20.0"     // for version dependency updates
+    id "com.github.johnrengelman.shadow" version "4.0.3"    // fatJar aka shadowJar
+}
 
-group 'io.chirpbot.twitchdev'
-version '1.0.1'
+group "io.chirpbot.twitchdev"
+version "1.1.0-SNAPSHOT"
 
-sourceCompatibility = 1.8
+sourceCompatibility = targetCompatibility = 1.8
+
+mainClassName = "io.chirpbot.twitchdev.TwitchDev"
 
 repositories {
     jcenter()
-    mavenCentral()
     maven {
         url "https://jitpack.io"
     }
@@ -25,17 +31,19 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
-task fatJar(type: Jar) {
+shadowJar {
+    classifier "all"
+}
+
+tasks.withType(Jar) {
+    def attrib = manifest.attributes
+    attrib.put("Implementation-Title", "TwitchDev Bot")
+    attrib.put("Implementation-Version", project.version)
     manifest {
-        attributes 'Implementation-Title': 'TwitchDev Bot',
-        'Implementation-Version': version,
-        'Main-Class': 'io.chirpbot.twitchdev.TwitchDev'
+        attributes(attrib)
     }
-    baseName = project.name + '-all'
-    from {
-        configurations.compile.collect {
-            it.isDirectory()? it : zipTree(it)
-        }
-    }
-    with jar
+}
+
+wrapper {
+    distributionType = Wrapper.DistributionType.ALL
 }

--- a/src/main/java/io/chirpbot/twitchdev/handlers/MessageHandler.java
+++ b/src/main/java/io/chirpbot/twitchdev/handlers/MessageHandler.java
@@ -16,7 +16,7 @@ public class MessageHandler {
 	@EventSubscriber
 	public void onMessageReceived(MessageReceivedEvent event) {
 		for(ICommand command : TwitchDev.commands.getCommandList()) {
-			if(event.getMessage().getContent().contains(command.getCommand())) {
+			if(event.getMessage().getContent().startsWith(command.getCommand())) {
 				command.executeResponse(event.getMessage().getContent(), event);
 			}
 		}

--- a/src/main/java/io/chirpbot/twitchdev/helpers/cURL.java
+++ b/src/main/java/io/chirpbot/twitchdev/helpers/cURL.java
@@ -1,5 +1,6 @@
 package io.chirpbot.twitchdev.helpers;
 
+import java.nio.charset.StandardCharsets;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -13,7 +14,7 @@ public class cURL {
 
 	public static JSONObject GET(String www) throws IOException {
 		URL url = new URL(www);
-		BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), "UTF-8"));
+		BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
 		String out = reader.lines().collect(Collectors.joining());
 		return new JSONObject(out);
 	}
@@ -23,14 +24,7 @@ public class cURL {
 	}
 
 	public static String buildURL(String www, HashMap<String, String> params) {
-		StringBuilder out = new StringBuilder();
-		out.append(www);
-		int c = 0;
-		for(String k : params.keySet()) {
-			if (c == 0) out.append(String.format("?%s=%s", k, params.get(k)));
-			else out.append(String.format("&%s=%s", k, params.get(k)));
-			c++;
-		}
-		return out.toString();
+		return www + params.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue())
+				.collect(Collectors.joining("&", "?", ""));
 	}
 }


### PR DESCRIPTION
* Fixing command prefix.
* simplify code using JDK8's Streams
* `build.gradle` has been improved
  - adding `plugins {}` block to simplify import plugins
  - remove `mavenCentral()` which `jcenter()` mirroring Central Repository
  - task `fatJar` is now `shadowJar` with classifier `all`
  - using `Wrapper.DistributionType.ALL` to autocomplete coding *.gradle files and creating own script (create buildSrc directory to create own build script)
  - All manifest attributes are be unchanged

### Additional notes
A way faster is using JDA, which contains [OkHttpClient](https://github.com/square/okhttp) with [nv-websocket](https://github.com/TakahikoKawasaki/nv-websocket-client) projects. D4J is handled by Jetty, when is a mostly not recommended for machines, which have lower performance. If you wish I can rewrite your cURL code using [OkHttpClient](https://github.com/square/okhttp). You got a base of commands, which it needs more adjustments with prefixes and API's. [JDA-Utilites](https://github.com/JDA-Applications/JDA-Utilities) is good practice for building bootstrapping commands. If you wish make this code reactive... I see no issue. Any words are welcome.